### PR TITLE
Add method for datetime.date object return

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ $ pip install chronyk
 '2014-09-09'
 >>> t.relativestring()
 '3 days ago'
+>>> t.date()
+datetime.date(2014, 9, 9)
+>>> t.datetime()
+datetime.datetime(2014, 9, 9, 5, 59, 39)
 ```
 
 **Input validation:**

--- a/chronyk/chronyk.py
+++ b/chronyk/chronyk.py
@@ -420,6 +420,20 @@ class Chronyk:
         if timezone is None:
             timezone = self.timezone
         return datetime.datetime.fromtimestamp(self.__timestamp__ - timezone)
+        
+    def date(self, timezone=None):
+        """Returns a datetime.date object.
+        This object retains all information, including timezones.
+        
+        :param timezone = self.timezone
+            The timezone (in seconds west of UTC) to return the value in. By
+            default, the timezone used when constructing the class is used
+            (local one by default). To use UTC, use timezone = 0. To use the
+            local tz, use timezone = chronyk.LOCALTZ.
+        """
+        if timezone is None:
+            timezone = self.timezone
+        return datetime.date.fromtimestamp(self.__timestamp__ - timezone)
 
     def timestamp(self, timezone=None):
         """Returns a timestamp (seconds since the epoch).
@@ -713,4 +727,3 @@ class ChronykDelta:
             return textsegs[0]
 
         return ", ".join(textsegs[:-1]) + " and " + textsegs[-1]
-

--- a/test_chronyk.py
+++ b/test_chronyk.py
@@ -169,6 +169,10 @@ def test_typeerror():
 def test_datetime():
     timest = currentutc()
     assert Chronyk(timest, timezone=0).datetime() == datetime.datetime.fromtimestamp(timest)
+    
+def test_date():
+    timest = currentutc()
+    assert Chronyk(timest, timezone=0).date() == datetime.date.fromtimestamp(timest)
 
 def test_timest_1():
     timest = time.time()


### PR DESCRIPTION
Using this for a local project and found myself wanting datetime.date() versions of Chronyk objects. Since datetime.datetime() functionality is already there, I just patched in a version for date(). 

In case the change seems worthwhile, I also built a test and dropped in a demo for the readme.

Thanks for building a great module!