### PR TITLE
Support for abbreviated months with trailing periods

### DIFF
--- a/chronyk/chronyk.py
+++ b/chronyk/chronyk.py
@@ -382,7 +382,7 @@ class Chronyk:
                 return timestamp
 
     def __fromstring__(self, timestr):
-        timestr = timestr.lower().strip()
+        timestr = timestr.lower().strip().replace(". ", " ")
 
         # COMMON NAMES FOR TIMES
         if timestr in ["today", "now", "this week", "this month", "this day"]:


### PR DESCRIPTION
Strings such as "Jan. 1, 2013" fail to parse, due to the presence of the trailing period in the abbreviated month. Since this is a very common way to write out dates, it seems worthwhile to support.

The proposed fix is very simple - just remove all periods from the input text when they're followed by a space.

This does not break any of the current tests, and looking through the current pattern list I don't think it would break any functionality. Due to the requirement of a space after the period, formats such as "d.m.y" are preserved.

Any thoughts?